### PR TITLE
Added headerLevel capabilities...

### DIFF
--- a/MarkdownLog/Header.cs
+++ b/MarkdownLog/Header.cs
@@ -29,8 +29,8 @@ namespace MarkdownLog
     {
         public Header(string format, params object[] args) : this(string.Format(format, args)) { }
 
-        public Header(string text) : base(text, '=')
-        {
-        }
+        public Header(string text) : base(text, '=') { }
+
+		public Header(string text, int headerLevel) : base(text, headerLevel) { }
     }
 }

--- a/MarkdownLog/HeaderBase.cs
+++ b/MarkdownLog/HeaderBase.cs
@@ -31,6 +31,7 @@ namespace MarkdownLog
     {
         private readonly char _underlineChar;
         private readonly string _text = "";
+		private int _headerLevel = 0;
 
         protected HeaderBase(string text, char underlineChar)
         {
@@ -38,25 +39,58 @@ namespace MarkdownLog
             _underlineChar = underlineChar;
         }
 
+		protected HeaderBase(string text, int headerLevel)
+		{
+			_text = text ?? "";
+			_headerLevel = headerLevel;
+		}
+
+
+
         public override string ToMarkdown()
         {
-            var builder = new StringBuilder();
-
-            var textLines = _text.SplitByLine();
-
-            foreach(var textLine in textLines)
-            {
-                if (builder.Length > 0)
-                    builder.AppendLine();
-
-                var markdown = textLine.EscapeMarkdownCharacters();
-                builder.Append(markdown);
-                builder.AppendLine();
-                builder.Append(new string(_underlineChar, markdown.Length));
-                builder.AppendLine();
-            }
-
-            return builder.ToString();
+			return (0 == _headerLevel) ? ToUnderlinedMarkdown() : ToNumericMarkdown();
         }
+
+
+
+		private string ToNumericMarkdown()
+		{
+			var builder = new StringBuilder();
+			var textLines = _text.SplitByLine();
+			var linePrefix = new string('#', _headerLevel);
+
+			foreach (var textLine in textLines)
+			{
+				builder.Append(linePrefix);
+				builder.Append(textLine);
+				builder.AppendLine();
+			}
+
+			return builder.ToString();
+		}
+
+
+
+		private string ToUnderlinedMarkdown()
+		{
+			var builder = new StringBuilder();
+
+			var textLines = _text.SplitByLine();
+
+			foreach (var textLine in textLines)
+			{
+				if (builder.Length > 0)
+					builder.AppendLine();
+
+				var markdown = textLine.EscapeMarkdownCharacters();
+				builder.Append(markdown);
+				builder.AppendLine();
+				builder.Append(new string(_underlineChar, markdown.Length));
+				builder.AppendLine();
+			}
+
+			return builder.ToString();
+		}
     }
 }

--- a/MarkdownLog/MarkDownBuilderExtensions.cs
+++ b/MarkdownLog/MarkDownBuilderExtensions.cs
@@ -37,6 +37,18 @@ namespace MarkdownLog
             return new Header(text);
         }
 
+
+		/// <summary>
+		/// Returns a markdown string that will translate to <![CDATA[<h1> to <h6>]]>
+		/// </summary>
+		/// <param name="text"></param>
+		/// <param name="headerLevel">Should be between 1 and 6 to product a <![CDATA[<h1> ... <h6>]]></param>
+		/// <returns></returns>
+		public static Header ToMarkdownHeader(this string text, int headerLevel)
+		{
+			return new Header(text, headerLevel);
+		}
+
         public static SubHeader ToMarkdownSubHeader(this string text)
         {
             return new SubHeader(text);

--- a/MarkdownLog/SubHeader.cs
+++ b/MarkdownLog/SubHeader.cs
@@ -29,8 +29,8 @@ namespace MarkdownLog
     {
         public SubHeader(string format, params object[] args) : this(string.Format(format, args)) { }
 
-        public SubHeader(string text) : base(text, '-')
-        {
-        }
+        public SubHeader(string text) : base(text, '-') { }
+
+		public SubHeader(string text, int headerLevel) : base(text, headerLevel) { }
     }
 }

--- a/UnitTests/DocumentationExamples.cs
+++ b/UnitTests/DocumentationExamples.cs
@@ -133,6 +133,11 @@ namespace UnitTests.MarkdownLog
         {
             Console.Write("The Origin of the Species".ToMarkdownHeader());
             Console.Write("By Means of Natural Selection".ToMarkdownSubHeader());
+
+			for (int headerLevel = 1; headerLevel <= 6; headerLevel++)
+			{
+				Console.Write(("This should be a header " + headerLevel).ToMarkdownHeader(headerLevel));
+			}
         }
 
         [TestMethod]


### PR DESCRIPTION
...to HeaderBase, Header, and SubHeader; added overloaded ToMarkdownHeader extension method to support headerLevel; added to the HeaderExamples test method.

I modified the HeaderBase, Header, and SubHeader classes to produce markdown that translates to &lt;h1&gt; through &lt;h6&gt;.

Usage:   `"This is wrapped an H3 element when translated to HTML.".ToMarkdownHeader(3);`

I only overloaded the `ToMarkdownHeader()` method, not the subhead method, because I didn't see the point.  Both methods would have produced the exact same results.

Modifications are all done via method overloads and a little refactoring of private implementation code - so this constitutes a non-breaking change to the existing code base.